### PR TITLE
Nexus 3 metadata, npm folder and checksum file issue solutions

### DIFF
--- a/nex2art/core/Npm.py
+++ b/nex2art/core/Npm.py
@@ -18,7 +18,7 @@ class Npm(object):
     def checkContent(self, path, name):
         try:
             with open(path, 'r') as m: js = json.load(m)
-            return js['name'] == name
+            return js['name'].endswith(name)
         except: return False
 
     def deployPaths(self, localpath, metapath, repo, repopath):

--- a/nex2art/core/Upload.py
+++ b/nex2art/core/Upload.py
@@ -169,7 +169,6 @@ class Upload(object):
                         if not os.path.isfile(mp): continue
                         blobbase = os.path.splitext(meta)[0]
                         if self.isNexus3ChecksumFile(chapdir, blobbase): continue
-                        if self.isNexus3NpmFolder(chapdir, blobbase): continue
                         blob = blobbase + '.bytes'
                         ap = os.path.join(chapdir, blob)
                         if not os.path.isfile(ap): continue
@@ -199,7 +198,7 @@ class Upload(object):
             else: store = self.acquireLocation2(path, metapath)
             paths = self.deployPaths(path, metapath, repo, store)
             for lpath, mpath, rep, rpath, props in paths:
-                localheaders = headers
+                localheaders = headers.copy()
                 if self.scr.nexus.nexusversion == 3:
                     props = self.acquireMetadata3(metapath)
                     localheaders['X-Artifactory-Last-Modified'] = props['creationTime']
@@ -408,10 +407,5 @@ class Upload(object):
 
     def isNexus3ChecksumFile(self, chapdir, fname):
         blobpropertiesfile = os.path.join(chapdir, fname + '.properties')
-        blobproperties = open(blobpropertiesfile, 'r').read()
-        return ('.md5' in blobproperties) or ('.sha1' in blobproperties) or ('.sha256' in blobproperties)
-
-    def isNexus3NpmFolder(self, chapdir, fname):
-        blobpropertiesfile = os.path.join(chapdir, fname + '.properties')
-        blobproperties = open(blobpropertiesfile, 'r').read()
-        return (re.search('blob-name=@', blobproperties)) and (not re.search('blob-name=@.+\..*', blobproperties))
+        blobname = self.acquireMetadata3(blobpropertiesfile)['@BlobStore.blob-name']
+        return blobname.endswith('.md5') or blobname.endswith('.sha1') or blobname.endswith('.sha256')

--- a/nex2art/core/Upload.py
+++ b/nex2art/core/Upload.py
@@ -199,11 +199,15 @@ class Upload(object):
             else: store = self.acquireLocation2(path, metapath)
             paths = self.deployPaths(path, metapath, repo, store)
             for lpath, mpath, rep, rpath, props in paths:
+                localheaders = headers
                 if self.scr.nexus.nexusversion == 3:
+                    props = self.acquireMetadata3(metapath)
+                    localheaders['X-Artifactory-Last-Modified'] = props['creationTime']
+                    localheaders['X-Artifactory-Created'] = props['creationTime']
                     csdata = self.acquireChecksums3(lpath, mpath)
                     if csdata == None: continue
                 else: csdata = self.acquireChecksums2(lpath, mpath)
-                self.deploy(url, headers, props, lpath, rep, rpath, csdata)
+                self.deploy(url, localheaders, props, lpath, rep, rpath, csdata)
 
     def deploy(self, url, headers, props, localpath, repo, repopath, csdata):
         sha2, sha1, md5 = csdata

--- a/nex2art/core/Upload.py
+++ b/nex2art/core/Upload.py
@@ -169,6 +169,7 @@ class Upload(object):
                         if not os.path.isfile(mp): continue
                         blobbase = os.path.splitext(meta)[0]
                         if self.isNexus3ChecksumFile(chapdir, blobbase): continue
+                        if self.isNexus3NpmFolder(chapdir, blobbase): continue
                         blob = blobbase + '.bytes'
                         ap = os.path.join(chapdir, blob)
                         if not os.path.isfile(ap): continue
@@ -405,3 +406,8 @@ class Upload(object):
         blobpropertiesfile = os.path.join(chapdir, fname + '.properties')
         blobproperties = open(blobpropertiesfile, 'r').read()
         return ('.md5' in blobproperties) or ('.sha1' in blobproperties) or ('.sha256' in blobproperties)
+
+    def isNexus3NpmFolder(self, chapdir, fname):
+        blobpropertiesfile = os.path.join(chapdir, fname + '.properties')
+        blobproperties = open(blobpropertiesfile, 'r').read()
+        return (re.search('blob-name=@', blobproperties)) and (not re.search('blob-name=@.+\..*', blobproperties))

--- a/nex2art/core/Upload.py
+++ b/nex2art/core/Upload.py
@@ -167,7 +167,9 @@ class Upload(object):
                         if not meta.endswith('.properties'): continue
                         mp = os.path.join(chapdir, meta)
                         if not os.path.isfile(mp): continue
-                        blob = os.path.splitext(meta)[0] + '.bytes'
+                        blobbase = os.path.splitext(meta)[0]
+                        if self.isNexus3ChecksumFile(chapdir, blobbase): continue
+                        blob = blobbase + '.bytes'
                         ap = os.path.join(chapdir, blob)
                         if not os.path.isfile(ap): continue
                         self.log.info("Found artifact for deployment: %s", blob)
@@ -398,3 +400,8 @@ class Upload(object):
             self.parent.prog.stepsmap['Artifacts'][4] += 1
             if error: self.parent.prog.stepsmap['Artifacts'][3] += 1
             self.parent.prog.refresh()
+
+    def isNexus3ChecksumFile(self, chapdir, fname):
+        blobpropertiesfile = os.path.join(chapdir, fname + '.properties')
+        blobproperties = open(blobpropertiesfile, 'r').read()
+        return ('.md5' in blobproperties) or ('.sha1' in blobproperties) or ('.sha256' in blobproperties)


### PR DESCRIPTION
our systems is a Nexus 3 instance initial migrated over from a nexus 2 instance. This resulted in us maintaining a system of storing md5 and sha1 files alongside our artifacts. When using this migrator it picked up these files and attempted to upload them to Artifactory, not only is this a fruitless task as artifactory manages that for us, when it attempts the `checksum upload` the checksum files contents is not included, and as Artifactory is a clever thing it knows its a checksum and looks inside the file, resulting in some empty string issues.

Not only this but we discovered intermittent issues with npm repos being uploaded, this oroginated from the folders metadata being uploaded as a file and thus blocking any further files in that directory structure.

We also have a reliance on timestamps in certain areas, and this migration process replaces them with the uploaded time, there is a change in here which alters this.

And these changes resulted in a successful migration