### PR TITLE
Add content-length header to deployChecksum request

### DIFF
--- a/nex2art/core/Upload.py
+++ b/nex2art/core/Upload.py
@@ -270,6 +270,7 @@ class Upload(object):
 
     def deployChecksum(self, url, headers):
         chksumheaders = {'X-Checksum-Deploy': 'true'}
+        chksumheaders['Content-Length'] = 0
         chksumheaders.update(headers)
         req = PutRequest(url, headers=chksumheaders)
         try:


### PR DESCRIPTION
This prevents 411 Length Required failures when making the deploy checksum request. I was receiving this failure on upload from a Nexus 2 to an Artifactory 6.19.1 repository. 